### PR TITLE
await demonitor calls

### DIFF
--- a/pyrlang/dist_proto/base_dist_protocol.py
+++ b/pyrlang/dist_proto/base_dist_protocol.py
@@ -276,7 +276,7 @@ class BaseDistProtocol(asyncio.Protocol):
             (_, sender, target, ref) = control_term
             from pyrlang.errors import ProcessNotFoundError
             try:
-                return n.demonitor_process(origin_pid=sender, target=target,
+                return await n.demonitor_process(origin_pid=sender, target=target,
                                            ref=ref)
             except ProcessNotFoundError:
                 pass

--- a/pyrlang/gen/server.py
+++ b/pyrlang/gen/server.py
@@ -227,7 +227,7 @@ class GenServerInterface(object):
 
         match = Match([(pattern, lambda x: x[1])])
         res = await self._calling_process.receive(match, timeout)
-        self._node.demonitor_process(calling_pid, self._destination_pid, m_ref)
+        await self._node.demonitor_process(calling_pid, self._destination_pid, m_ref)
         return res
 
     async def call(self, request, timeout=5):

--- a/pyrlang/node.py
+++ b/pyrlang/node.py
@@ -596,7 +596,7 @@ class Node:
             return self._demonitor_local_process(origin_pid, target_pid,
                                                  ref=ref)
         # Target process is remote, and we need to send monitor message
-        return self._demonitor_remote_process(origin_pid, target_pid, ref=ref)
+        return await self._demonitor_remote_process(origin_pid, target_pid, ref=ref)
 
     async def _demonitor_remote_process(self, origin_pid: Pid, target_pid: Pid,
                                         ref: Reference):


### PR DESCRIPTION
I noticed that this latest version of pyrlang that we want to use for OTP26 had some errors with not awaiting some calls to async functions

I have added those here